### PR TITLE
you can now set/use the user nickname to query version one

### DIFF
--- a/src/com/psafarov/intellij/versionone/VersionOneRepository.scala
+++ b/src/com/psafarov/intellij/versionone/VersionOneRepository.scala
@@ -21,6 +21,7 @@ class VersionOneRepository(repositoryType: VersionOneRepositoryType) extends Bas
 
   var myScope = Scope.ALL
   var myTeam = ""
+  var myNickname = ""
 
   def this() = this(null)
 
@@ -30,12 +31,16 @@ class VersionOneRepository(repositoryType: VersionOneRepositoryType) extends Bas
   def getTeam = myTeam
   def setTeam(team: String) = myTeam = team
 
+  def getNickname = myNickname
+  def setNickname(nickname: String) = myNickname = nickname
+
   override def clone() = {
     val cloned = new VersionOneRepository(getRepositoryType.asInstanceOf[VersionOneRepositoryType])
     cloned.setUrl(getUrl)
     cloned.setPassword(getPassword)
     cloned.setUsername(getUsername)
     cloned.setUseProxy(isUseProxy)
+    cloned.myNickname = myNickname
     cloned.myScope = myScope
     cloned.myTeam = myTeam
     cloned
@@ -68,7 +73,7 @@ class VersionOneRepository(repositoryType: VersionOneRepositoryType) extends Bas
     myScope match {
       case Scope.ALL =>
       case Scope.TEAM => query.where("Team.Name") = myTeam
-      case Scope.USER => query.where("Owners.Nickname") = getUsername
+      case Scope.USER => query.where("Owners.Nickname") = myNickname
     }
 
     val json = sendQuery(query)

--- a/src/com/psafarov/intellij/versionone/VersionOneRepositoryEditor.scala
+++ b/src/com/psafarov/intellij/versionone/VersionOneRepositoryEditor.scala
@@ -18,11 +18,18 @@ class VersionOneRepositoryEditor(repository: VersionOneRepository, project: Proj
   var myScopeInput: ComboBox = _
   installListener(myScopeInput)
 
+  var myNicknameLabel: JBLabel = _
+  var myNicknameInput: JBTextField = _
+  installListener(myNicknameInput)
+
   var myTeamLabel: JBLabel = _
   var myTeamInput: JBTextField = _
   installListener(myTeamInput)
 
   override def createCustomPanel = {
+    myNicknameLabel = new JBLabel("Nickname:", SwingConstants.RIGHT)
+    myNicknameInput = new JBTextField(repository.getNickname)
+
     myScopeLabel = new JBLabel("Scope:", SwingConstants.RIGHT)
     val myScopeModel = new ListComboBoxModel(Scope.values.toList)
     myScopeModel.setSelectedItem(repository.getScope)
@@ -33,6 +40,7 @@ class VersionOneRepositoryEditor(repository: VersionOneRepository, project: Proj
     switchTeamInput()
 
     FormBuilder.createFormBuilder
+      .addLabeledComponent(myNicknameLabel, myNicknameInput)
       .addLabeledComponent(myScopeLabel, myScopeInput)
       .addLabeledComponent(myTeamLabel, myTeamInput)
       .setVertical(false)
@@ -43,6 +51,7 @@ class VersionOneRepositoryEditor(repository: VersionOneRepository, project: Proj
     super.apply()
     repository.setScope(myScopeInput.getSelectedItem.toString)
     repository.setTeam(myTeamInput.getText)
+    repository.setNickname(myNicknameInput.getText)
     switchTeamInput()
   }
 
@@ -51,6 +60,7 @@ class VersionOneRepositoryEditor(repository: VersionOneRepository, project: Proj
 
   override def setAnchor(anchor: JComponent) = {
     super.setAnchor(anchor)
+    myNicknameLabel.setAnchor(anchor)
     myScopeLabel.setAnchor(anchor)
     myTeamLabel.setAnchor(anchor)
   }


### PR DESCRIPTION
got your plugin working in my setup. the problem was the default query wasn't exactly working since the username that i use to login in version one is not the same as the 'user' you need to query by (no clue what's the deal and how come they are different).

so i added the ability to add the nickname when you setup the plugin and use that to query version one. i can now see my tasks and everything seems to be working
